### PR TITLE
[update] dev CD env file path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,7 @@ jobs:
               "export HOST_PORT='8000'",
               "export APP_PORT='8000'",
               "export HEALTH_PATH='/'",
-              "export APP_ENV_PATH='/home/ubuntu/app/.env'",
+              "export APP_ENV_PATH='/home/ubuntu/codoc/chat-ai.env'",
               "export APP_ENV_CONTENT_BASE64='${APP_ENV_CONTENT_BASE64}'",
               "nohup bash '${DEV_DEPLOY_SCRIPT_PATH}' > /home/ubuntu/codoc/logs/chat-dev-deploy.log 2>&1 < /dev/null &",
               "echo started"


### PR DESCRIPTION
## 📝 작업 내용
- dev CD 배포 워크플로우에서 env 파일 경로를 `/home/ubuntu/codoc/chat-ai.env`로 변경했습니다.
- SSM 배포 시 기존 `/home/ubuntu/app/.env` 대신 `chat-ai.env`를 사용하도록 수정했습니다.

## 📢 참고 사항
- `.github/workflows/cd.yml` 한 줄만 수정한 PR입니다.